### PR TITLE
Fix: Correct logout logic to ensure proper state update

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -181,17 +181,15 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   // Sign out user
   const logout = async (): Promise<void> => {
     try {
-      await signOut(auth);
-      setUser(null);
-      setProfile(null);
-      setUserRole(null);
-      
-      // Clear stored data
+      // Clear stored data first
       await Promise.all([
         AsyncStorage.removeItem(STORAGE_KEYS.USER_ROLE),
         AsyncStorage.removeItem(STORAGE_KEYS.CART_ITEMS),
         AsyncStorage.removeItem(STORAGE_KEYS.RECENTLY_VIEWED)
       ]);
+
+      // Sign out from Firebase, which will trigger the onAuthStateChanged listener
+      await signOut(auth);
     } catch (error) {
       console.error('Logout error:', error);
       throw error;


### PR DESCRIPTION
The logout function in `AuthContext.tsx` was manually setting the user state to null, in addition to the `onAuthStateChanged` listener doing the same thing. This redundancy could lead to race conditions or unpredictable state updates, preventing the app from navigating to the login screen after logout.

This commit refactors the `logout` function to only be responsible for clearing local storage and initiating the Firebase sign-out. The `onAuthStateChanged` listener is now the single source of truth for updating the authentication state, ensuring a more robust and predictable logout process.